### PR TITLE
fixing synchronization issue in setting header

### DIFF
--- a/authz/providers/azure/azure.go
+++ b/authz/providers/azure/azure.go
@@ -81,7 +81,7 @@ func (s Authorizer) Check(request *authzv1.SubjectAccessReviewSpec, store authz.
 	}
 
 	// check if user is system accounts
-	if strings.HasPrefix(strings.ToLower(request.User), "system") {
+	if strings.HasPrefix(strings.ToLower(request.User), "system:") {
 		glog.V(3).Infof("returning no op to system accounts")
 		return &authzv1.SubjectAccessReviewStatus{Allowed: false, Reason: rbac.NoOpinionVerdict}, nil
 	}

--- a/authz/providers/azure/rbac/rbac.go
+++ b/authz/providers/azure/rbac/rbac.go
@@ -72,7 +72,7 @@ type AccessInfo struct {
 	retrieveGroupMemberships       bool
 	skipAuthzForNonAADUsers        bool
 	allowNonResDiscoveryPathAccess bool
-	lock                           *sync.Mutex
+	lock                           *sync.RWMutex
 }
 
 func getClusterType(clsType string) string {
@@ -109,7 +109,7 @@ func newAccessInfo(tokenProvider graph.TokenProvider, rbacURL *url.URL, opts aut
 	}
 
 	u.clusterType = getClusterType(opts.AuthzMode)
-	u.lock = &sync.Mutex{}
+	u.lock = &sync.RWMutex{}
 
 	return u, nil
 }
@@ -127,7 +127,7 @@ func New(opts authzOpts.Options, authopts auth.Options, authzInfo *AuthzInfo) (*
 			fmt.Sprintf("%s%s/oauth2/v2.0/token", authzInfo.AADEndpoint, authopts.TenantID),
 			fmt.Sprintf("%s.default", authzInfo.ARMEndPoint))
 	case authzOpts.AKSAuthzMode:
-		tokenProvider = graph.NewAKSTokenProvider(opts.AKSAuthzURL, authopts.TenantID)
+		tokenProvider = graph.NewAKSTokenProvider(opts.AKSAuthzTokenURL, authopts.TenantID)
 	}
 
 	return newAccessInfo(tokenProvider, rbacURL, opts)
@@ -154,11 +154,7 @@ func (a *AccessInfo) RefreshToken() error {
 }
 
 func (a *AccessInfo) IsTokenExpired() bool {
-	if a.expiresAt.Before(time.Now()) {
-		return true
-	} else {
-		return false
-	}
+	return a.expiresAt.Before(time.Now())
 }
 
 func (a *AccessInfo) ShouldSkipAuthzCheckForNonAADUsers() bool {
@@ -232,8 +228,13 @@ func (a *AccessInfo) CheckAccess(request *authzv1.SubjectAccessReviewSpec) (*aut
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating check access request")
 	}
-	// Set the auth headers for the request
-	req.Header = a.headers
+
+	{
+		a.lock.RLock()
+		defer a.lock.RUnlock()
+		// Set the auth headers for the request
+		req.Header = a.headers
+	}
 
 	if glog.V(10) {
 		cmd, _ := http2curl.GetCurlCommand(req)

--- a/authz/providers/azure/rbac/rbac_test.go
+++ b/authz/providers/azure/rbac/rbac_test.go
@@ -44,7 +44,7 @@ func getAPIServerAndAccessInfo(returnCode int, body, clusterType, resourceId str
 		clusterType:     clusterType,
 		azureResourceId: resourceId,
 		armCallLimit:    0,
-		lock:            &sync.Mutex{}}
+		lock:            &sync.RWMutex{}}
 	return ts, u
 }
 
@@ -114,7 +114,7 @@ func getAuthServerAndAccessInfo(returnCode int, body, clientID, clientSecret str
 	u := &AccessInfo{
 		client:  http.DefaultClient,
 		headers: http.Header{},
-		lock:    &sync.Mutex{},
+		lock:    &sync.RWMutex{},
 	}
 	u.tokenProvider = graph.NewClientCredentialTokenProvider(clientID, clientSecret, ts.URL, "")
 	return ts, u
@@ -156,7 +156,7 @@ func TestLogin(t *testing.T) {
 		u := &AccessInfo{
 			client:  http.DefaultClient,
 			headers: http.Header{},
-			lock:    &sync.Mutex{},
+			lock:    &sync.RWMutex{},
 		}
 		u.tokenProvider = graph.NewClientCredentialTokenProvider("CIA", "outcome", badURL, "")
 

--- a/docs/reference/guard_get_installer.md
+++ b/docs/reference/guard_get_installer.md
@@ -34,7 +34,7 @@ guard get installer [flags]
       --azure.environment string             Azure cloud environment
       --azure.tenant-id string               MS Graph application tenant id to use
       --azure.use-group-uid                  Use group UID for authentication instead of group display name (default true)
-      --azure.aks-authz-url string           url to call for AKS Authz flow
+      --azure.aks-authz-token-url string     url to call for AKS Authz flow
       --azure.authz-mode string              authz mode to call RBAC api, valid value is either aks or arc
       --azure.resource-id  string            azure cluster resource id (/subscriptions/<SubscriptionId>/resourceGroups/<RGname>/providers/Microsoft.ContainerService/managedClusters/<clustername> for AKS or /subscriptions/<SubscriptionId>/resourceGroups/<RGname>/providers/Microsoft.Kubernetes/connectedClusters/<clustername> for arc) to be used as scope for RBAC check
       --azure.skip-authz-check strings       comma separated list of user email ids for which Azure RBAC will be skipped. (default empty)


### PR DESCRIPTION
Added synchronization while setting rbac header to avoid panic. 
Moved to RWMutex instead of Mutex to allow concurrent reads on a.header

Also fixed some minor comments like changing system to system: and updated aks token parameter name in Authz configuration list.